### PR TITLE
Disable `no-loss-of-precision`

### DIFF
--- a/index.js
+++ b/index.js
@@ -58,6 +58,8 @@ module.exports = {
         'no-unused-vars': ['warn', { argsIgnorePattern: '^_' }],
         quotes: ['error', 'single'],
         semi: ['error', 'always'],
+
+        'no-loss-of-precision': 'off',
       },
     },
     {
@@ -96,6 +98,7 @@ module.exports = {
         '@typescript-eslint/no-explicit-any': 'off',
         '@typescript-eslint/no-empty-function': 'off',
         '@typescript-eslint/no-extra-semi': 'off',
+        '@typescript-eslint/no-loss-of-precision': 'off',
         '@typescript-eslint/no-this-alias': 'off',
         '@typescript-eslint/no-var-requires': 'off',
       },


### PR DESCRIPTION
緯度経度を表す値で、精度の高すぎる数値が返ってくる場合があり、そのような場合に数値が想定された値であるかを確かめるテストを書くため、精度の高すぎる数値をハードコードする必要がある場合があるため、`no-loss-of-precision` を無効化した。