### PR TITLE
Allow console

### DIFF
--- a/index.js
+++ b/index.js
@@ -19,7 +19,6 @@ module.exports = {
     'key-spacing': 'error',
     'keyword-spacing': 'error',
     'generator-star-spacing': 'error',
-    'no-console': 'warn',
     'no-useless-computed-key': 'error',
     'no-useless-rename': 'error',
     'no-var': 'error',


### PR DESCRIPTION
[`no-console`](https://eslint.org/docs/latest/rules/no-console) ルールの削除を行う PR です。

`console.log()` などを使っている箇所も結構多いので、[`no-console`](https://eslint.org/docs/latest/rules/no-console) ルールは `@geolonia/eslint-config` からは外しても良いのではないかと思うのですが、どうでしょうか?
`console.log()` などを禁止したいプロジェクトでは、個別の eslintrc.js で `no-console` を指定する方向で。