### PR TITLE
Add eslint-plugin-promise

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,6 +2,7 @@ module.exports = {
   extends: [
     'eslint:recommended',
     'plugin:editorconfig/all',
+    'plugin:promise/recommended',
   ],
   env: {
     es2024: true,
@@ -9,7 +10,7 @@ module.exports = {
   parserOptions: {
     sourceType: 'module',
   },
-  plugins: ['editorconfig', 'import'],
+  plugins: ['editorconfig', 'import', 'promise'],
   rules: {
     'array-callback-return': 'error',
     'arrow-parens': 'error',
@@ -46,6 +47,7 @@ module.exports = {
         '**/webpack.config.js',
       ]
     }],
+    'promise/prefer-await-to-then': 'error',
   },
   overrides: [
     {

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "@typescript-eslint/parser": "^5.46.1",
     "eslint-plugin-editorconfig": "^4.0.3",
     "eslint-plugin-import": "^2.26.0",
+    "eslint-plugin-promise": "^6.1.1",
     "eslint-plugin-react": "^7.31.11",
     "eslint-plugin-react-hooks": "^4.6.0",
     "typescript": "^5.0.0"


### PR DESCRIPTION
eslint-plugin-promise を導入し、`plugin:promise/recommended` を `extends` しました。

また、`promise/prefer-await-to-then` を有効化し、`.then()` `.catch()` `.finally()` を使わずに async/await 構文を利用させるようにしました。